### PR TITLE
fix wrong address response.

### DIFF
--- a/rpc/utils/utils.go
+++ b/rpc/utils/utils.go
@@ -13,7 +13,6 @@ import (
 
 // NewRPCTransaction returns a transaction that will serialize to the RPC representation.
 func NewRPCTransaction(dbTx *model.Transaction) (*RPCTransaction, error) {
-	to := common.HexToAddress(dbTx.ToAddr)
 	gasPrice, _ := new(big.Int).SetString(dbTx.GasPrice, 10)
 	gasFee, _ := new(big.Int).SetString(dbTx.GasFeeCap, 10)
 	gasTip, _ := new(big.Int).SetString(dbTx.GasTipCap, 10)
@@ -35,7 +34,6 @@ func NewRPCTransaction(dbTx *model.Transaction) (*RPCTransaction, error) {
 	blockHash := common.HexToHash(dbTx.BlockHash)
 	txIndex := hexutil.Uint64(dbTx.Index)
 	resTx := &RPCTransaction{
-		From:             common.HexToAddress(dbTx.FromAddr),
 		Gas:              hexutil.Uint64(dbTx.Gas),
 		GasPrice:         (*hexutil.Big)(gasPrice),
 		GasFeeCap:        (*hexutil.Big)(gasFee),
@@ -43,7 +41,6 @@ func NewRPCTransaction(dbTx *model.Transaction) (*RPCTransaction, error) {
 		Hash:             common.HexToHash(dbTx.Hash),
 		Input:            common.Hex2Bytes(dbTx.Data),
 		Nonce:            hexutil.Uint64(dbTx.Nonce),
-		To:               &to,
 		Value:            (*hexutil.Big)(value),
 		Type:             hexutil.Uint64(dbTx.Type),
 		Accesses:         &accesses,
@@ -54,6 +51,19 @@ func NewRPCTransaction(dbTx *model.Transaction) (*RPCTransaction, error) {
 		BlockHash:        &blockHash,
 		BlockNumber:      (*hexutil.Big)(new(big.Int).SetUint64(dbTx.Round)),
 		TransactionIndex: &txIndex,
+	}
+
+	if len(dbTx.FromAddr) == 0 {
+		resTx.From = common.Address{}
+	} else {
+		resTx.From = common.HexToAddress(dbTx.FromAddr)
+	}
+
+	if len(dbTx.ToAddr) == 0 {
+		resTx.To = nil
+	} else {
+		to := common.HexToAddress(dbTx.ToAddr)
+		resTx.To = &to
 	}
 
 	return resTx, nil


### PR DESCRIPTION
`{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "blockHash": "0xfa047e3b061f7af8426cf3fe8a97f068b293cef050763adff9203ff4fd1186ce",
        "blockNumber": "0x11c3",
        "from": "0x28d8e86ad82e60fd5ebe82107e245d33505815ee",
        "gas": "0x8c308",
        "gasPrice": "0x0",
        "maxFeePerGas": "0x0",
        "maxPriorityFeePerGas": "0x0",
        "hash": "0x389140f4e8b8af51a487e47b84fd6f1626355f904821eece31f0914bebc2d643",
        "input": "......",
        "nonce": "0x0",
        "to": "0x0000000000000000000000000000000000000000",
        "transactionIndex": "0x0",
        "value": "0x0",
        "type": "0x0",
        "accessList": null,
        "chainId": "0x0",
        "v": "0x14a4d",
        "r": "0x38dcc8e20fb371a29abb1d2cc345cc00d8ce8bfbe03f14f73b77ffc1262e436e",
        "s": "0x261b3d8529b52e20b28bd8ea3d064a681c430923950425c1f7e16caf5c57f7d1"
    }
} `

the contract address in transaction is 0x0000000000000000000000000000000000000000.